### PR TITLE
Android configs

### DIFF
--- a/korge-gradle-plugin/src/main/kotlin/com/soywiz/korge/gradle/KorgeExtension.kt
+++ b/korge-gradle-plugin/src/main/kotlin/com/soywiz/korge/gradle/KorgeExtension.kt
@@ -160,7 +160,7 @@ class KorgeExtension(val project: Project) {
 		extraEntryPoints.add(Entrypoint(name, jvmMainClassName))
 	}
 
-	var androidMinSdk: Int = 14
+	var androidMinSdk: Int = 16
 	var androidCompileSdk: Int = 28
 	var androidTargetSdk: Int = 28
 

--- a/korge-gradle-plugin/src/main/kotlin/com/soywiz/korge/gradle/KorgeExtension.kt
+++ b/korge-gradle-plugin/src/main/kotlin/com/soywiz/korge/gradle/KorgeExtension.kt
@@ -160,7 +160,17 @@ class KorgeExtension(val project: Project) {
 		extraEntryPoints.add(Entrypoint(name, jvmMainClassName))
 	}
 
-	var androidMinSdk: String? = null
+	var androidMinSdk: Int = 14
+	var androidCompileSdk: Int = 28
+	var androidTargetSdk: Int = 28
+
+	@JvmOverloads
+	fun androidSdk(compileSdk: Int, minSdk: Int, targetSdk: Int) {
+		androidMinSdk = minSdk
+		androidCompileSdk = compileSdk
+		androidTargetSdk = targetSdk
+	}
+
 	internal var _androidAppendBuildGradle: String? = null
 
 	@JvmOverloads
@@ -253,7 +263,6 @@ class KorgeExtension(val project: Project) {
 		// Required to have webgl on android emulator?
 		// https://crosswalk-project.org/documentation/cordova.html
 		// https://github.com/crosswalk-project/cordova-plugin-crosswalk-webview/issues/205#issuecomment-371669478
-		if (androidMinSdk == null) androidMinSdk = "20"
 		cordovaPlugin("cordova-plugin-crosswalk-webview", version = "2.4.0")
 		androidAppendBuildGradle("""
         	configurations.all {

--- a/korge-gradle-plugin/src/main/kotlin/com/soywiz/korge/gradle/targets/android/Android.kt
+++ b/korge-gradle-plugin/src/main/kotlin/com/soywiz/korge/gradle/targets/android/Android.kt
@@ -132,7 +132,7 @@ fun Project.configureNativeAndroid() {
 								line("targetSdkVersion ${korge.androidTargetSdk}")
 								line("versionCode 1")
 								line("versionName '1.0'")
-								line("buildConfigField 'boolean', 'FULLSCREEN', '${korge.fullscreen}'")
+//								line("buildConfigField 'boolean', 'FULLSCREEN', '${korge.fullscreen}'")
 								line("testInstrumentationRunner 'android.support.test.runner.AndroidJUnitRunner'")
                                 val manifestPlaceholdersStr = korge.configs.map { it.key + ":" + it.value.quoted }.joinToString(", ")
 								line("manifestPlaceholders = ${if (manifestPlaceholdersStr.isEmpty()) "[:]" else "[$manifestPlaceholdersStr]" }")

--- a/korge-gradle-plugin/src/main/kotlin/com/soywiz/korge/gradle/targets/android/Android.kt
+++ b/korge-gradle-plugin/src/main/kotlin/com/soywiz/korge/gradle/targets/android/Android.kt
@@ -132,6 +132,7 @@ fun Project.configureNativeAndroid() {
 								line("targetSdkVersion ${korge.androidTargetSdk}")
 								line("versionCode 1")
 								line("versionName '1.0'")
+								line("buildConfigField 'boolean', 'FULLSCREEN', '${korge.fullscreen}'")
 								line("testInstrumentationRunner 'android.support.test.runner.AndroidJUnitRunner'")
                                 val manifestPlaceholdersStr = korge.configs.map { it.key + ":" + it.value.quoted }.joinToString(", ")
 								line("manifestPlaceholders = ${if (manifestPlaceholdersStr.isEmpty()) "[:]" else "[$manifestPlaceholdersStr]" }")
@@ -286,7 +287,7 @@ fun writeAndroidManifest(outputFolder: File, korge: KorgeExtension) {
 						line("android:icon=\"@mipmap/icon\"")
 						// // line("android:icon=\"@android:drawable/sym_def_app_icon\"")
 						line("android:roundIcon=\"@android:drawable/sym_def_app_icon\"")
-						line("android:theme=\"@android:style/Theme.Black.NoTitleBar.Fullscreen\"")
+						line("android:theme=\"@android:style/Theme.Holo.NoActionBar\"")
 					}
 
 

--- a/korge-gradle-plugin/src/main/kotlin/com/soywiz/korge/gradle/targets/android/Android.kt
+++ b/korge-gradle-plugin/src/main/kotlin/com/soywiz/korge/gradle/targets/android/Android.kt
@@ -299,7 +299,14 @@ fun writeAndroidManifest(outputFolder: File, korge: KorgeExtension) {
 						line(text)
 					}
 
-					line("<activity android:name=\".MainActivity\">")
+					line("<activity android:name=\".MainActivity\"")
+					indent {
+						when (korge.orientation) {
+							Orientation.LANDSCAPE -> line("android:screenOrientation=\"landscape\"")
+							Orientation.PORTRAIT -> line("android:screenOrientation=\"portrait\"")
+						}
+					}
+					line(">")
 
 					if (!korge.androidLibrary) {
 						indent {

--- a/korge-gradle-plugin/src/main/kotlin/com/soywiz/korge/gradle/targets/android/Android.kt
+++ b/korge-gradle-plugin/src/main/kotlin/com/soywiz/korge/gradle/targets/android/Android.kt
@@ -119,16 +119,17 @@ fun Project.configureNativeAndroid() {
 								line("exclude '**/*.kotlin_metadata'")
 								line("exclude '**/*.kotlin_builtins'")
                             }
-							line("compileSdkVersion 28")
+							line("compileSdkVersion ${korge.androidCompileSdk}")
 							line("defaultConfig") {
-								line("multiDexEnabled true")
+								if (korge.androidMinSdk < 21)
+									line("multiDexEnabled true")
 
 								if (!korge.androidLibrary) {
 									line("applicationId '$androidPackageName'")
 								}
 
-								line("minSdkVersion 19")
-								line("targetSdkVersion 28")
+								line("minSdkVersion ${korge.androidMinSdk}")
+								line("targetSdkVersion ${korge.androidTargetSdk}")
 								line("versionCode 1")
 								line("versionName '1.0'")
 								line("testInstrumentationRunner 'android.support.test.runner.AndroidJUnitRunner'")
@@ -169,7 +170,8 @@ fun Project.configureNativeAndroid() {
 						line("dependencies") {
 							line("implementation fileTree(dir: 'libs', include: ['*.jar'])")
 							line("implementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlinVersion'")
-							line("implementation 'com.android.support:multidex:1.0.3'")
+							if (korge.androidMinSdk < 21)
+								line("implementation 'com.android.support:multidex:1.0.3'")
 
 							//line("api 'org.jetbrains.kotlinx:kotlinx-coroutines-android:$coroutinesVersion'")
 							for ((name, version) in resolvedArtifacts) {


### PR DESCRIPTION
Follow up to fix minSdk which is bumped to 16. The style in android manifest is changed to show status bar by default. This PR works along with https://github.com/korlibs/korgw/pull/32 to support proper fullscreen on Android. BuildConfig field is commented until the decision is made whether to use this approach or not.